### PR TITLE
Type-safe input URLs as method arguments whenever possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +150,17 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "lazy_static"
@@ -174,6 +195,7 @@ name = "libreoffice-rs"
 version = "0.3.0"
 dependencies = [
  "bindgen",
+ "url",
 ]
 
 [[package]]
@@ -184,6 +206,12 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -212,6 +240,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "proc-macro2"
@@ -285,16 +319,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dee68f85cab8cf68dec42158baf3a79a1cdc065a8b103025965d6ccb7f6cbd"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib","rlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-
+url = "2.2.2"
 
 [build-dependencies]
 bindgen = "0.59"

--- a/src/urls.rs
+++ b/src/urls.rs
@@ -1,0 +1,114 @@
+use std::fmt;
+use std::path::Path;
+use url::Url;
+
+use crate::error::Error;
+
+/// Type-safe URL "container" for LibreOffice documents
+#[derive(Debug, Clone)]
+pub struct DocUrl(String);
+
+impl fmt::Display for DocUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Construct a type-safe `DocUrl` instance for a given path
+/// - This method **does check** if the file actually exists, which you may not want
+/// - If the provided file path is relative, then it'll be converted to an absolute path
+/// - Once the absolute path is obtained, this delegates to [local_as_abs]
+///
+/// # Arguments
+/// * `path` - An relative or absolute path that for an existing local file
+///
+/// ```
+/// use libreoffice_rs::urls;
+///
+/// # fn  main() -> Result<(), Box<dyn std::error::Error>> {
+/// let valid_url_ret = urls::local_into_abs("./test_data/test.odt");
+/// assert!(valid_url_ret.is_ok(), "{}", valid_url_ret.err().unwrap());
+///
+/// let invalid_url_ret = urls::local_into_abs("does_not_exist.odt");
+/// assert!(invalid_url_ret.is_err(), "Computed an absolute path URL for a nonexistent file!");
+///
+/// #  Ok(())
+/// # }
+/// ```
+pub fn local_into_abs<S: Into<String>>(path: S) -> Result<DocUrl, Error> {
+    let doc_path = path.into();
+
+    match std::fs::canonicalize(&doc_path) {
+        Ok(doc_abspath) => local_as_abs(doc_abspath.display().to_string()),
+        Err(ex) => {
+            let msg = format!("Does the file exist at {}? {}", doc_path, ex.to_string());
+            Err(Error::new(msg))
+        }
+    }
+}
+
+/// Construct a type-safe `DocUrl` instance for a given absolute local path
+/// - This method doesn't check if the file actually exists yet
+/// - The provided file path must be an absolute location, per LibreOffice expectations
+///
+/// # Arguments
+/// * `path` - An absolute path on the local filesystem
+///
+/// ```
+/// use libreoffice_rs::urls;
+///
+/// # fn  main() -> Result<(), Box<dyn std::error::Error>> {
+/// let relative_path_ret = urls::local_as_abs("./test_data/test.odt");
+/// assert!(relative_path_ret.is_err(), "{}", relative_path_ret.err().unwrap());
+///
+/// #  Ok(())
+/// # }
+/// ```
+pub fn local_as_abs<S: Into<String>>(path: S) -> Result<DocUrl, Error> {
+    let uri_location = path.into();
+    let p = Path::new(&uri_location);
+
+    if !p.is_absolute() {
+        return Err(Error::new(format!("The file path {} must be absolute!", &uri_location)));
+    }
+
+    let url_ret = Url::from_file_path(&uri_location);
+
+    match url_ret {
+        Ok(url_value) => {
+            Ok(DocUrl(url_value.as_str().to_owned()))
+        },
+        Err(ex) => {
+            return Err(Error::new(format!("Failed to parse as URL {}! {:?}", uri_location, ex)));
+        }
+    }
+}
+
+/// Construct a type-safe DocUrl instance if the document remote URI is valid
+///
+/// # Arguments
+/// * `uri` - A document URI
+///
+/// # Example
+///
+/// ```
+/// use libreoffice_rs::urls;
+///
+/// # fn  main() -> Result<(), Box<dyn std::error::Error>> {
+/// let valid_url_ret = urls::remote("http://google.com");
+///
+/// assert!(valid_url_ret.is_ok(), "{:?}", valid_url_ret.err());
+///
+/// #  Ok(())
+/// # }
+/// ```
+pub fn remote<S: Into<String>>(uri: S) -> Result<DocUrl, Error> {
+    let uri_location = uri.into();
+    let uri_location_str = uri_location.as_str();
+
+    if let Err(ex) = Url::parse(uri_location_str) {
+        return Err(Error::new(format!("Failed to parse URI {}! {}", uri_location, ex.to_string())));
+    }
+
+    Ok(DocUrl(uri_location))
+}


### PR DESCRIPTION
Fix issue #5 with the following changes
- Add the `url` crate dependency for document URL validation
- Add a new `DocUrl` type to hold pre-validate document URLs (relaxed validation)
- Refactor few existing methods and tests to use the new `DocUrl` type