### PR TITLE
Allow cross-compilation for arm64 fix #12

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,22 +133,22 @@ impl Office {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn register_callback<F: FnMut(i32, *const i8) + 'static>(
+    pub fn register_callback<F: FnMut(std::os::raw::c_int, *const std::os::raw::c_char) + 'static>(
         &mut self,
         cb: F,
     ) -> Result<(), Error> {
         unsafe {
             // LibreOfficeKitCallback typedef (int nType, const char* pPayload, void* pData);
             unsafe extern "C" fn shim(
-                _type: i32,
-                _payload: *const i8,
+                _type: std::os::raw::c_int,
+                _payload: *const std::os::raw::c_char,
                 data: *mut std::os::raw::c_void,
             ) {
                 let a: *mut Box<dyn FnMut()> = data as *mut Box<dyn FnMut()>;
                 let f: &mut (dyn FnMut()) = &mut **a;
                 let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
             }
-            let a: *mut Box<dyn FnMut(i32, *const i8)> = Box::into_raw(Box::new(Box::new(cb)));
+            let a: *mut Box<dyn FnMut(std::os::raw::c_int, *const std::os::raw::c_char)> = Box::into_raw(Box::new(Box::new(cb)));
             let data: *mut std::os::raw::c_void = a as *mut std::ffi::c_void;
             let callback: LibreOfficeKitCallback = Some(shim);
             (*self.lok_clz).registerCallback.unwrap()(self.lok, callback, data);


### PR DESCRIPTION
Do not use directly `i32` or `i8` types for callback registration parameters, as this doesn't compile when targeting arm64.

- `i8` type do work fine on `amd64` Linux, however for arm64 `u8` type is expected (`i8` to `c_char`)
- The same is applied for the i32 parameter (`i32` to `c_int`)