### PR TITLE
fix: register callback

### DIFF
--- a/tests/test_password_callback.rs
+++ b/tests/test_password_callback.rs
@@ -13,7 +13,7 @@ fn test_password_callback() {
         .set_optional_features([LibreOfficeKitOptionalFeatures::LOK_FEATURE_DOCUMENT_PASSWORD])
         .unwrap();
 
-    const LOK_CALLBACK_DOCUMENT_PASSWORD: i32 = 20;
+    const LOK_CALLBACK_DOCUMENT_PASSWORD: std::os::raw::c_int = 20;
 
     office
         .register_callback({

--- a/tests/test_password_callback.rs
+++ b/tests/test_password_callback.rs
@@ -1,0 +1,34 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use libreoffice_rs::{urls, LibreOfficeKitOptionalFeatures, Office};
+
+#[test]
+#[ignore = "requires libreoffice to run this test"]
+fn test_password_callback() {
+    let doc_url = urls::local_into_abs("./test_data/test_password.odt").unwrap();
+    let password = "test";
+    let password_was_set = AtomicBool::new(false);
+    let mut office = Office::new("/usr/lib/libreoffice/program").unwrap();
+    office
+        .set_optional_features([LibreOfficeKitOptionalFeatures::LOK_FEATURE_DOCUMENT_PASSWORD])
+        .unwrap();
+
+    const LOK_CALLBACK_DOCUMENT_PASSWORD: i32 = 20;
+
+    office
+        .register_callback({
+            let mut office = office.clone();
+            let doc_url = doc_url.clone();
+            move |ty, _| {
+                if ty == LOK_CALLBACK_DOCUMENT_PASSWORD && !password_was_set.load(Ordering::Acquire)
+                {
+                    office
+                        .set_document_password(doc_url.clone(), password)
+                        .unwrap();
+                    password_was_set.store(true, Ordering::Release);
+                }
+            }
+        })
+        .unwrap();
+    let mut _doc = office.document_load(doc_url).unwrap();
+}


### PR DESCRIPTION
## Description

Fixes register callback shim not using the values  from the callback. Currently the user defined callback is being called with whatever junk values are at the memory addresses the function ends up getting called with.

## Changes
- Updates callback shim
- Adds ignored test for trying the callback on a sample from test_data